### PR TITLE
Baseline2026site

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You can build and serve the site inside a Docker-based development container.
 
 Prerequisites:
 - VS Code + Dev Containers extension (or GitHub Codespaces)
+   * When installing Git as apart of setting up VS Code, ensure that you choose "Checkout as-is, commit Unix-style line endings"
 - Docker running locally
 
 How to use:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -3,7 +3,7 @@ main:
   - title: "Attend"
     children:
       - title: "Register"
-        url: https://www.eventbrite.com/e/security-bsides-orlando-2025-conference-tickets-1497767435719
+        url: /register/
       - title: "Schedule"
         url: /schedule/
       - title: "Workshops"
@@ -12,22 +12,22 @@ main:
         url: /speakers/
       - title: "Venue Info"
         url: /venue/
-      - title: "Map"
-        url: /map/
+      #- title: "Map"
+      #  url: /map/
       - title: "Policies"
         url: /policies/
   - title: "Explore"
     children:
       - title: "Activities"
         url: /event/
-      - title: "Career Village"
-        url: /career_village/
-      - title: "Social Engineering Adventure"
-        url: /se_village/
-      - title: "PreShow"
-        url: /preshow/
-      - title: "After Party"
-        url: /after_party/
+      #- title: "Career Village"
+      #  url: /career_village/
+      #- title: "Social Engineering Adventure"
+      #  url: /se_village/
+      #- title: "PreShow"
+      #  url: /preshow/
+      #- title: "After Party"
+      #  url: /after_party/
   - title: "Get Involved"
     children:
       - title: "Join Us"

--- a/about.md
+++ b/about.md
@@ -51,7 +51,7 @@ Now in our 13th year, BSides Orlando has grown from modest beginnings and seeks 
 
 * 2021 – BSides Orlando does Byte Sized! a live CTF style, virtual event
 
-* 2022-26 - BSides Orlando is back live at Full Sail University
+* 2022-25 - BSides Orlando is back live at Full Sail University
 
 * 2025 - BSides Orlando breaks 1000 tickets sold
 

--- a/about.md
+++ b/about.md
@@ -25,7 +25,7 @@ classes: about-page
 
 # History
 
-Now in our 10th year, BSides Orlando has grown from modest beginnings and seeks to stay true to our roots.
+Now in our 13th year, BSides Orlando has grown from modest beginnings and seeks to stay true to our roots.
 
 <img src="{{ '/assets/images/bsidesorl-timeline.svg' | prepend: site.baseurl }}" alt="BSides Orlando Timeline" width="500">
 
@@ -51,7 +51,9 @@ Now in our 10th year, BSides Orlando has grown from modest beginnings and seeks 
 
 * 2021 – BSides Orlando does Byte Sized! a live CTF style, virtual event
 
-* 2022-25 - BSides Orlando is back live at Full Sail University
+* 2022-26 - BSides Orlando is back live at Full Sail University
+
+* 2025 - BSides Orlando breaks 1000 tickets sold
 
 # What is a Security BSides?
 

--- a/event.md
+++ b/event.md
@@ -1,17 +1,19 @@
 ---
-layout: splash
-title: Event
+layout: single
+title: Event Activites
 permalink: /event/
 classes: event-page
+toc: true
+toc_label: "Villages and More"
 ---
-# Event Activities
+
 BSides Orlando is built around learning, doing, and connecting. From hands-on villages to contests, talks, and parties, there’s something for every hacker, maker, and security enthusiast.
 
 ---
 
-## Competitions & Contests
+# Competitions & Contests
 
-### Sunshine Capture the Flag (CTF)
+## Sunshine Capture the Flag (CTF)
 <div class="event-card">
   <img src="{{ '/assets/images/ctf.png' | prepend: site.baseurl }}" alt="Capture the Flag">
   <div class="event-content">
@@ -21,7 +23,7 @@ BSides Orlando is built around learning, doing, and connecting. From hands-on vi
   </div>
 </div>
 
-### Contests & Chill
+## Contests & Chill
 Need a change of pace? Contests & Chill is your space to reset, play, or hack on something fun:
 - <strong>Fox Hunts</strong>: tutorial and competitive  
 - <strong>RFID Badge Cloning</strong> demos  
@@ -31,9 +33,9 @@ Need a change of pace? Contests & Chill is your space to reset, play, or hack on
 
 ---
 
-## Villages
+# Villages
 
-### Soldering Village
+## Soldering Village
 <div class="event-card">
   <img src="{{ '/assets/images/soldering.png' | prepend: site.baseurl }}" alt="Soldering Village">
   <div class="event-content">
@@ -41,7 +43,7 @@ Need a change of pace? Contests & Chill is your space to reset, play, or hack on
   </div>
 </div>
 
-### Lockpick Village (LPV)
+## Lockpick Village (LPV)
 <div class="event-card">
   <img src="{{ '/assets/images/lpv.png' | prepend: site.baseurl }}" alt="Lockpick Village">
   <div class="event-content">
@@ -49,11 +51,11 @@ Need a change of pace? Contests & Chill is your space to reset, play, or hack on
   </div>
 </div>
 
-### <a href="{{ site.baseurl }}/se_village/">Social Engineering Adventure</a>
+## <a href="{{ site.baseurl }}/se_village/">Social Engineering Adventure</a>
 Hack the human element. At the SE Adventure Village, explore how persuasion, psychology, and trust are used to gain access — and how to defend against it.  
 Expect <strong>OSINT challenges</strong>, an <strong>AI Vishing Contest</strong>, and live talks that mix fun with practical takeaways.
 
-### <a href="{{ site.baseurl }}/career_village/">Career Village</a>
+## <a href="{{ site.baseurl }}/career_village/">Career Village</a>
 Level up your career journey. Career Village offers:
 - Resume reviews  
 - Professional headshots  
@@ -61,37 +63,37 @@ Level up your career journey. Career Village offers:
 - A job board of open positions  
 Plus fun networking games like <strong>BINGO</strong> and a <strong>Scavenger Hunt</strong> that will take you across the con. Check out the <a href="{{ site.baseurl }}/career_village/">Career Village page</a> for tips to get the most out of it.
 
-### Community Village
+## Community Village
 Cybersecurity is bigger than one event. Meet local community groups, learn what they’re building, and discover how you can get involved year-round.
 
-### Sponsor Village
+## Sponsor Village
 The companies and organizations that make BSides Orlando possible are here to meet you! Stop by their tables to check out demos, opportunities, and (of course) swag.
 
 ---
 
-## Talks & Unconference
+# Talks & Unconference
 
-### Unconference
+## Unconference
 Your voice belongs here. Sign up onsite to give a lightning talk (15 minutes or less) on anything you want to share — tools, tips, war stories, or ideas. Short, sharp, and community-driven, the Unconference stage is always full of surprises.
 
-### Village Talks
+## Village Talks
 Many villages feature their own short talks and demos. Drop by for sessions on topics like lockpicking basics, deepfake detection, vishing, and more. Check the onsite schedule for times and details.
 
 ---
 
-## Info & Logistics
+# Info & Logistics
 
-### Information & Swag
+## Information & Swag
 Registration and swag pickup are streamlined with split lines this year. Every attendee gets sponsor goodies and a collectible BSides Orlando sticker sheet. Trade extras at the sticker table and expand your collection.
 
-### Workshops
+## Workshops
 Workshops run the day before the main con. Past sessions have included malware forensics with Volatility 3, IoT hacking labs, and threat modeling. Space is limited, so plan ahead — details are at <a href="{{ site.baseurl }}/workshops/">bsidesorlando.org/workshops</a>.
 
 ---
 
-## Social & Networking
+# Social & Networking
 
-### After Party
+## After Party
 Keep the energy going after the talks wrap up.  
 **Saturday, Sept 27 | 7–10 PM | The Celeste Hotel, Celestial Ballroom**  
 - Cash bar (alcoholic & non-alcoholic options)  

--- a/event.md
+++ b/event.md
@@ -94,8 +94,4 @@ Workshops run the day before the main con. Past sessions have included malware f
 # Social & Networking
 
 ## After Party
-Keep the energy going after the talks wrap up.  
-**Saturday, Sept 27 | 7–10 PM | The Celeste Hotel, Celestial Ballroom**  
-- Cash bar (alcoholic & non-alcoholic options)  
-- Music, board games, and hallway-con vibes  
-- A relaxed place to connect, unwind, and celebrate the community  
+Keep the energy going after the talks wrap up. Keep an eye out for when this gets announced!

--- a/index.html
+++ b/index.html
@@ -12,17 +12,17 @@ header:
   - label: "Friday Pre-conference Workshop Tickets - Not for sale yet, but soon!"
     url: ""
 excerpt: >
-  Pre-conference Workshops: Coming Soon!<br />
-  Conference: Coming Soon!<br />
+  Pre-conference Workshops: September 25th<br />
+  Conference: September 26th<br />
   <small>Full Sail University</small>
 feature_row:
 - title: "Conference"
-  excerpt: "Join us for a day of learning, networking, and fun"
+  excerpt: "Join us for a day of learning, networking, and fun on September 26th!"
   url: "/event/"
   btn_label: "Learn More"
   btn_class: "btn--inverse"
 - title: "Workshops"
-  excerpt: "Skill up at one of the pre-conference workshops offered"
+  excerpt: "Skill up at one of the pre-conference workshops offered with separate purchase on September 25th"
   url: "/workshops/"
   btn_label: "Learn More"
   btn_class: "btn--inverse"

--- a/index.html
+++ b/index.html
@@ -3,24 +3,26 @@ layout: splash
 permalink: /
 header:
   overlay_color: "#222"
+  overlay_filter: .5
+  overlay_image: /assets/images/Orlando_Skyline.jpg 
   alignment: center
   actions:
-  - label: "Saturday Conference Tickets"
-    url: "https://www.eventbrite.com/e/security-bsides-orlando-2025-conference-tickets-1497767435719"
-  - label: "Friday Pre-conference Workshop Tickets"
-    url: "https://www.eventbrite.com/e/bsides-orlando-2025-workshops-tickets-1618524072069"
+  - label: "Saturday Conference Tickets - Not for sale yet, but soon!"
+    url: ""
+  - label: "Friday Pre-conference Workshop Tickets - Not for sale yet, but soon!"
+    url: ""
 excerpt: >
-  Pre-conference Workshops: September 26, 2025<br />
-  Conference: September 27, 2025<br />
+  Pre-conference Workshops: Coming Soon!<br />
+  Conference: Coming Soon!<br />
   <small>Full Sail University</small>
 feature_row:
 - title: "Conference"
-  excerpt: "Join us September 27, 2025 for a day of learning, networking, and fun"
+  excerpt: "Join us for a day of learning, networking, and fun"
   url: "/event/"
   btn_label: "Learn More"
   btn_class: "btn--inverse"
 - title: "Workshops"
-  excerpt: "Skill up at one of the pre-conference workshops offered on Friday September 26, 2025"
+  excerpt: "Skill up at one of the pre-conference workshops offered"
   url: "/workshops/"
   btn_label: "Learn More"
   btn_class: "btn--inverse"
@@ -30,7 +32,7 @@ feature_row:
   btn_label: "Learn More"
   btn_class: "btn--inverse"
 - title: "Speakers"
-  excerpt: "Without our speakers we'd have nothing to present! Call for Papers is closed! Notifications on accepted talks will be sent starting August 1st!"
+  excerpt: "Without our speakers we'd have nothing to present! Call for Papers is will open soon!"
   url: "/speakers/"
   btn_label: "See our Speakers!"
   btn_class: "btn--inverse"

--- a/past_events.md
+++ b/past_events.md
@@ -6,6 +6,8 @@ permalink: /past_events/
 # Past Events
 We are grateful for your continued interest and support in our cybersecurity initiatives. We invite you to explore the highlights of our past years' events through the links below. Each conference has been a remarkable journey of learning, collaboration, and innovation, and we are excited to share these moments with you. Thank you for being a part of our community and helping us advance the field of cybersecurity.
 
+## Bsides Orlando 2025
+<a href="https://2025.bsidesorlando.org/">BSides Orlando 2025</a>
 
 ## Bsides Orlando 2024
 <a href="https://2024.bsidesorlando.org/">BSides Orlando 2024</a>

--- a/preshow.md
+++ b/preshow.md
@@ -5,7 +5,12 @@ permalink: /preshow/
 classes: preshow-page
 ---
 
-# BSides 2025 PreShow Content
+# Current PreShows
+Unfortunately there's no pre-show content available yet, but keep your eyes peeled!
+
+# Historical PreShows
+
+## BSides 2025 PreShow Content
 
 <div class="event-card">
   <div class="event-content">

--- a/register.md
+++ b/register.md
@@ -4,6 +4,6 @@ title: Register for BSides Orlando
 permalink: /register/
 ---
 
-# BSides Orlando 2025 Conference Registration
+# BSides Orlando 2026 Conference Registration
 
 Unfortunately, tickets aren't on sale yet, but keep an eye out!

--- a/register.md
+++ b/register.md
@@ -1,0 +1,9 @@
+---
+layout: splash
+title: Register for BSides Orlando
+permalink: /register/
+---
+
+# BSides Orlando 2025 Conference Registration
+
+Unfortunately, tickets aren't on sale yet, but keep an eye out!

--- a/schedule.md
+++ b/schedule.md
@@ -1,11 +1,11 @@
 ---
 layout: splash
-title: Saturday Conference Schedule - BSides Orlando September 27, 2025
+title: Saturday Conference Schedule - BSides Orlando September 26, 2026
 permalink: /schedule/
 classes: schedule-page
 ---
 
-# BSides Orlando 2025 Conference Schedule
+# BSides Orlando 2026 Conference Schedule
 
 Schedule isn't available yet, though keep your eyes peeled!
 

--- a/schedule.md
+++ b/schedule.md
@@ -7,14 +7,7 @@ classes: schedule-page
 
 # BSides Orlando 2025 Conference Schedule
 
-<div class="schedule-embed">
-  <script type="text/javascript" src="https://sessionize.com/api/v2/u075vbmm/view/GridSmart"></script>
-  <noscript>
-    <p>View the full schedule on Sessionize:</p>
-    <p><a class="btn btn--primary" href="https://sessionize.com/bsides-orlando-2025/" target="_blank" rel="noopener">Open Schedule</a></p>
-  </noscript>
-  
-</div>
+Schedule isn't available yet, though keep your eyes peeled!
 
 _Schedule subject to change, updates will be posted here and at the conference._
 {: .text-center}

--- a/speakers.md
+++ b/speakers.md
@@ -8,3 +8,4 @@ permalink: /speakers/
 
 Currently call for papers isn't open yet, but keep your eyes peeled!
 
+ 

--- a/speakers.md
+++ b/speakers.md
@@ -1,11 +1,10 @@
 ---
 layout: splash
-title: Speakers - BSides Orlando 2025
+title: Speakers - BSides Orlando
 permalink: /speakers/
 ---
 
-# BSides Orlando 2025 Speakers
+# BSides Orlando 2026 Speakers
 
-These are our wonderful speakers, please give them all a hand!
+Currently call for papers isn't open yet, but keep your eyes peeled!
 
-<script type="text/javascript" src="https://sessionize.com/api/v2/orfms5ds/view/SpeakerWall"></script>

--- a/venue.md
+++ b/venue.md
@@ -20,7 +20,7 @@ classes: venue-page
 
 <div class="hotel-grid">
   <div class="hotel-card">
-    <a href="https://www.marriott.com/event-reservations/reservation-link.mi?id=1756325616692&key=GRP&app=resvlink" target="_blank" rel="noopener">The Celeste</a>
+    <a href="https://thecelestehotel.com/" target="_blank" rel="noopener">The Celeste</a>
   </div>
   <div class="hotel-card"><a href="https://www.wyndhamhotels.com/baymont/orlando-florida/baymont-orlando-east/overview" target="_blank" rel="noopener">Baymont</a></div>
   <div class="hotel-card"><a href="https://www.ihg.com/holidayinn/hotels/us/en/orlando/mcohs/hoteldetail" target="_blank" rel="noopener">Holiday Inn UCF</a></div>

--- a/venue.md
+++ b/venue.md
@@ -21,7 +21,6 @@ classes: venue-page
 <div class="hotel-grid">
   <div class="hotel-card">
     <a href="https://www.marriott.com/event-reservations/reservation-link.mi?id=1756325616692&key=GRP&app=resvlink" target="_blank" rel="noopener">The Celeste</a>
-    <p class="note">Room block — book soon!</p>
   </div>
   <div class="hotel-card"><a href="https://www.wyndhamhotels.com/baymont/orlando-florida/baymont-orlando-east/overview" target="_blank" rel="noopener">Baymont</a></div>
   <div class="hotel-card"><a href="https://www.ihg.com/holidayinn/hotels/us/en/orlando/mcohs/hoteldetail" target="_blank" rel="noopener">Holiday Inn UCF</a></div>

--- a/venue.md
+++ b/venue.md
@@ -1,12 +1,12 @@
 ---
 layout: splash
-title: Venue - BSides Orlando 2025
+title: Venue - BSides Orlando 2026
 permalink: /venue/
 classes: venue-page
 ---
 
 
-## Bsides Orlando 2025 Location
+## Bsides Orlando 2026 Location
 
 <div class="info-card">
   <h3>Full Sail Live</h3>

--- a/workshops.md
+++ b/workshops.md
@@ -6,10 +6,8 @@ permalink: /workshops/
 
 # BSides Orlando Pre-Conference Workshops
 
-**All workshops are held on Friday, Sept 26th and require pre-registration and a separate registration from the conference. Register for pre-conference Friday workshops [here](https://www.eventbrite.com/e/bsides-orlando-2025-workshops-tickets-1618524072069)**
+**All workshops are held on Friday and require pre-registration and a separate registration from the conference. Currently Workshop tickets are not for sale but hopefully soon!**
 {: .notice--info}
-
-<script type="text/javascript" src="https://sessionize.com/api/v2/zhy4jd09/view/Sessions"></script>
 
 **Looking for BSides Orlando conference schedule for Saturday? [Get more information here](/schedule.md)**  
 {: .notice--info}

--- a/workshops.md
+++ b/workshops.md
@@ -6,7 +6,7 @@ permalink: /workshops/
 
 # BSides Orlando Pre-Conference Workshops
 
-**All workshops are held on Friday and require pre-registration and a separate registration from the conference. Currently Workshop tickets are not for sale but hopefully soon!**
+**All workshops are held on Friday September 25th and require pre-registration and a separate registration from the conference. Currently Workshop tickets are not for sale but hopefully soon!**
 {: .notice--info}
 
 **Looking for BSides Orlando conference schedule for Saturday? [Get more information here](/schedule.md)**  


### PR DESCRIPTION
Removed info relating to 2025, and updated dates to 2026:
* Index: 
  changed date
  removed reg links
  Added temp background, let me know if it should be removed
* register:
  Temp page to fill the register link on the site
* schedule:
  removed last years sessionize
  updated dates
* speakers: 
  removed last years sessionize
* workshop:
  removed last years sessionize
  updated dates
* navigation:
  hid pages related to last years con until they can be updated
* about:
  updated history
* past events:
  Added 2025
* Preshow:
  Made a historical section and added a place holder for future
* Venus:
  Dates got updated